### PR TITLE
bugfix/if user goes left first in the carousel takes to a blank page

### DIFF
--- a/src/components/modules/Home/Carousel/index.jsx
+++ b/src/components/modules/Home/Carousel/index.jsx
@@ -18,7 +18,7 @@ export default function Carousel({ title, subTitle, slides }) {
           onClick={() => {
             currentSlideIndex !== 0
               ? setCurrentSlideIndex(currentSlideIndex - 1)
-              : setCurrentSlideIndex(slides.currentSlideIndex - 1);
+              : setCurrentSlideIndex(slides.length - 1);
           }}
         >
           <MdKeyboardArrowLeft />


### PR DESCRIPTION
### Final bug fix! - if the user goes left first in the carousel bringing to a blank page
Update to `setCurrentSlideIndex` to the last one by checking the length if the user is on the slide of index 0